### PR TITLE
change redeploy script

### DIFF
--- a/redeploy-site.sh
+++ b/redeploy-site.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# kill existing tmux sessions
-tmux kill-server
-
 # fetch the latest git repo
 git fetch && git reset origin/main --hard
 
@@ -10,5 +7,5 @@ git fetch && git reset origin/main --hard
 source .venv/bin/activate
 pip install -r requirements.txt
 
-# start detached tmux session and starts server
-tmux new-session -d -s portfolio-site "flask run --host=0.0.0.0 --port=5000"
+# restart the systemd service
+systemctl restart myportfolio


### PR DESCRIPTION
This pull request updates the deployment script for the portfolio site to transition from using `tmux` to managing the application with a `systemd` service. This change simplifies and standardizes the deployment process.

Deployment process changes:

* [`redeploy-site.sh`](diffhunk://#diff-bffc2b6e084d9361cc1a80997596cbe722bf9d026b376fd70dabb6da67223d4fL3-R11): Removed the use of `tmux` for managing the application, including killing existing `tmux` sessions and starting new ones. Instead, the script now restarts the `myportfolio` service using `systemctl`, aligning with best practices for service management.