### PR TITLE
feat: modify deploy script

### DIFF
--- a/redeploy-site.sh
+++ b/redeploy-site.sh
@@ -3,9 +3,8 @@
 # fetch the latest git repo
 git fetch && git reset origin/main --hard
 
-# install dependencies
-source .venv/bin/activate
-pip install -r requirements.txt
+# stop and remove the existing containers
+docker compose -f docker-compose.prod.yml down
 
-# restart the systemd service
-systemctl restart myportfolio
+# build and start the containers
+docker compose -f docker-compose.prod.yml up -d --build


### PR DESCRIPTION
This pull request updates the `redeploy-site.sh` script to transition from a virtual environment-based deployment to a Docker-based deployment process.

Deployment process changes:

* [`redeploy-site.sh`](diffhunk://#diff-bffc2b6e084d9361cc1a80997596cbe722bf9d026b376fd70dabb6da67223d4fL6-R10): Replaced the virtual environment setup (`source .venv/bin/activate` and `pip install -r requirements.txt`) with Docker commands to stop existing containers, remove them, and rebuild and start new containers using a production `docker-compose` file.