### PR TITLE
feat: add deployment github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
           chmod 600 ~/.ssh/deploy_key.pem
           cat >> ~/.ssh/config <<END
           Host my-vps
-            HostName $SSH_PRIVATE_KEY
+            HostName $SSH_IP
             User $SSH_USER
             IdentityFile ~/.ssh/deploy_key.pem
             StrictHostKeyChecking no


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automated deployment to a VPS server. The workflow is triggered on pushes to the `main` branch or via manual dispatch, and it sets up SSH access using secrets before connecting to the server.

Deployment automation:

* Added `.github/workflows/deploy.yml` to define a deployment workflow that runs on pushes to `main` or via workflow dispatch.
* Configures SSH access using secrets for private key, user, and IP, and sets up the SSH config for connecting to the VPS.
* Includes a step to SSH into the VPS and print the project directory to verify access and deployment location.