### PR TITLE
fix: wrong path for deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Deploy Site
         run: |
-          ssh my-vps '~/redeploy-site.sh'
+          ssh my-vps 'cd ${{ secrets.PROJECT_ROOT }} && chmod +x redeploy-site.sh && ./redeploy-site.sh'


### PR DESCRIPTION
This pull request updates the deployment step in the GitHub Actions workflow to improve reliability and security when deploying the site.

Deployment process improvement:

* In `.github/workflows/deploy.yml`, the deploy command now changes to the project root directory (using `${{ secrets.PROJECT_ROOT }}`), ensures the `redeploy-site.sh` script is executable, and then runs it, instead of just running the script directly.